### PR TITLE
Update Dockerfiles for CS142 and CS214

### DIFF
--- a/docker/cs142/Dockerfile
+++ b/docker/cs142/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 
 # CILK is not included in more recent versions of Ubuntu.
 
@@ -13,23 +13,28 @@ ENV TZ="America/Los_Angeles"
 RUN ln -snf /usr/share/zoneinfo/America/Los_Angeles /etc/localtime && echo America/Los_Angeles > /etc/timezone
 
 # Update software
-RUN apt -y update && apt -y upgrade
+RUN apt update && apt upgrade && apt-get install -y software-properties-common && add-apt-repository universe; echo 'deb [arch=amd64] http://archive.ubuntu.com/ubuntu focal main universe' >> /etc/apt/sources.list && apt update
 
 # Basic software that should be available in all containers.
-RUN apt -y install vim build-essential git wget tmux
+RUN apt -y install vim build-essential git wget tmux cmake libcilkrts5 gcc-7 g++-7 gcc-12 g++-12
 
-# Software specific to CS 142
-RUN apt -y install cmake libcilkrts5
+# Config alternatives
+RUN update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-12 150; update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-7 100; update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-11 50; update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-12 150; update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-7 100; update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-11 50
 
 #Parlaylib
-RUN cd /usr/local/src/
-RUN git clone https://github.com/cmuparlay/parlaylib.git
+RUN cd /usr/local/src/; git clone --shallow-since='2022-09-01' https://github.com/cmuparlay/parlaylib.git && cd parlaylib/ && git checkout 6302233
 
 #Build it
-RUN mkdir /usr/local/src/parlaylib/build
-RUN chmod 755 /usr/local/src/parlaylib/build
-
+RUN mkdir -p /usr/local/src/parlaylib/build && chmod 755 /usr/local/src/parlaylib/build
 RUN cd /usr/local/src/parlaylib/build; umask 0022; cmake ..; cmake --build . --target install
+
+#Patch for CilkPlus
+RUN cd /tmp/; wget http://198.74.113.240/cilk.tar && tar -xf cilk.tar && mv cilk /usr/lib/gcc/x86_64-linux-gnu/7/include/ && rm cilk.tar
+
+#OpenCilk
+RUN mkdir -p /usr/local/src/opencilk
+RUN wget -c https://github.com/OpenCilk/opencilk-project/releases/download/opencilk/v2.0/OpenCilk-2.0.0-x86_64-Linux-Ubuntu-20.04.sh -P /usr/local/src/opencilk
+RUN cd /usr/local/src/opencilk; sh OpenCilk-2.0.0-x86_64-Linux-Ubuntu-20.04.sh --prefix=/usr/local --skip-license --exclude-subdir
 
 # Command to run when a container starts
 CMD ["sleep", "infinity"]

--- a/docker/cs214/Dockerfile
+++ b/docker/cs214/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 
 # CILK is not included in more recent versions of Ubuntu.
 
@@ -13,23 +13,28 @@ ENV TZ="America/Los_Angeles"
 RUN ln -snf /usr/share/zoneinfo/America/Los_Angeles /etc/localtime && echo America/Los_Angeles > /etc/timezone
 
 # Update software
-RUN apt -y update && apt -y upgrade
+RUN apt update && apt upgrade && apt-get install -y software-properties-common && add-apt-repository universe; echo 'deb [arch=amd64] http://archive.ubuntu.com/ubuntu focal main universe' >> /etc/apt/sources.list && apt update
 
 # Basic software that should be available in all containers.
-RUN apt -y install vim build-essential git wget tmux
+RUN apt -y install vim build-essential git wget tmux cmake libcilkrts5 gcc-7 g++-7 gcc-12 g++-12
 
-# Software specific to CS 214
-RUN apt -y install cmake libcilkrts5
+# Config alternatives
+RUN update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-12 150; update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-7 100; update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-11 50; update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-12 150; update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-7 100; update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-11 50
 
 #Parlaylib
-RUN cd /usr/local/src/
-RUN git clone https://github.com/cmuparlay/parlaylib.git
+RUN cd /usr/local/src/; git clone --shallow-since='2022-09-01' https://github.com/cmuparlay/parlaylib.git && cd parlaylib/ && git checkout 6302233
 
 #Build it
-RUN mkdir /usr/local/src/parlaylib/build
-RUN chmod 755 /usr/local/src/parlaylib/build
-
+RUN mkdir -p /usr/local/src/parlaylib/build && chmod 755 /usr/local/src/parlaylib/build
 RUN cd /usr/local/src/parlaylib/build; umask 0022; cmake ..; cmake --build . --target install
+
+#Patch for CilkPlus
+RUN cd /tmp/; wget http://198.74.113.240/cilk.tar && tar -xf cilk.tar && mv cilk /usr/lib/gcc/x86_64-linux-gnu/7/include/ && rm cilk.tar
+
+#OpenCilk
+RUN mkdir -p /usr/local/src/opencilk
+RUN wget -c https://github.com/OpenCilk/opencilk-project/releases/download/opencilk/v2.0/OpenCilk-2.0.0-x86_64-Linux-Ubuntu-20.04.sh -P /usr/local/src/opencilk
+RUN cd /usr/local/src/opencilk; sh OpenCilk-2.0.0-x86_64-Linux-Ubuntu-20.04.sh --prefix=/usr/local --skip-license --exclude-subdir
 
 # Command to run when a container starts
 CMD ["sleep", "infinity"]


### PR DESCRIPTION
Install more software/ libraries to satisfy the course requirements
- add support for CilkPlus
- add support for OpenCilk

The Dockerfile has been verified working but hasn't been tested on Singularity.
Please note the base image has been changed to Ubuntu 22.04 because of compatibility.

Thanks,
Zheqi and Xiaojun